### PR TITLE
Add main section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "lightweight",
         "javascript"
     ],
+    "main": "./dist/js/jCaptcha.js",
     "devDependencies": {
         "@babel/core": "^7.1.2",
         "@babel/preset-env": "^7.1.0",


### PR DESCRIPTION
Allow shorter require
https://docs.npmjs.com/files/package.json#main

Also README should be corrected to use 
```
import jCaptcha from 'js-captcha/dist/js/jCaptcha';
// or after this PR
import jCaptcha from 'js-captcha';
```
in instruction for requiring the JS file